### PR TITLE
Add "metadata" field

### DIFF
--- a/devhub_types/src/dnarepo_entry_types.rs
+++ b/devhub_types/src/dnarepo_entry_types.rs
@@ -90,6 +90,7 @@ pub struct DnaEntry {
     pub published_at: u64,
     pub last_updated: u64,
     pub developer: DeveloperProfileLocation,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -111,6 +112,7 @@ pub struct DnaSummary {
     pub last_updated: u64,
     pub developer: AgentPubKey,
     pub deprecation: bool,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -129,6 +131,7 @@ pub struct DnaInfo {
     pub published_at: u64,
     pub last_updated: u64,
     pub developer: DeveloperProfileLocation,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -150,6 +153,7 @@ impl DnaEntry {
 	    last_updated: self.last_updated.clone(),
 	    developer: self.developer.clone(),
 	    deprecation: self.deprecation.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -162,6 +166,7 @@ impl DnaEntry {
 	    last_updated: self.last_updated.clone(),
 	    developer: self.developer.pubkey.clone(),
 	    deprecation: self.deprecation.clone().map_or(false, |_| true),
+	    metadata: self.metadata.clone(),
 	}
     }
 }
@@ -192,6 +197,7 @@ pub struct DnaVersionEntry {
     // pub properties: Option<serde_yaml::Value>, // does this make sense?  Intended as a DNA's default properties?
     pub hdk_version: String,
     pub zomes: Vec<ZomeReference>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 
 impl EntryModel for DnaVersionEntry {
@@ -210,6 +216,7 @@ pub struct DnaVersionSummary {
     pub wasm_hash : String,
     pub hdk_version: String,
     pub zomes: Vec<ZomeReference>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for DnaVersionSummary {
     fn get_type(&self) -> EntityType {
@@ -228,6 +235,7 @@ pub struct DnaVersionInfo {
     pub wasm_hash : String,
     pub hdk_version: String,
     pub zomes: HashMap<String, Entity<ZomeVersionSummary>>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for DnaVersionInfo {
     fn get_type(&self) -> EntityType {
@@ -297,6 +305,7 @@ impl DnaVersionEntry {
 		    })
 		})
 		.collect(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -309,6 +318,7 @@ impl DnaVersionEntry {
 	    wasm_hash: self.wasm_hash.clone(),
 	    hdk_version: self.hdk_version.clone(),
 	    zomes: self.zomes.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 }
@@ -326,6 +336,7 @@ pub struct ZomeEntry {
     pub published_at: u64,
     pub last_updated: u64,
     pub developer: DeveloperProfileLocation,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub deprecation: Option<DeprecationNotice>,
@@ -346,6 +357,7 @@ pub struct ZomeSummary {
     pub last_updated: u64,
     pub developer: AgentPubKey,
     pub deprecation: bool,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for ZomeSummary {
     fn get_type(&self) -> EntityType {
@@ -361,6 +373,7 @@ pub struct ZomeInfo {
     pub published_at: u64,
     pub last_updated: u64,
     pub developer: DeveloperProfileLocation,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub deprecation: Option<DeprecationNotice>,
@@ -380,6 +393,7 @@ impl ZomeEntry {
 	    last_updated: self.last_updated.clone(),
 	    developer: self.developer.clone(),
 	    deprecation: self.deprecation.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -391,6 +405,7 @@ impl ZomeEntry {
 	    last_updated: self.last_updated.clone(),
 	    developer: self.developer.pubkey.clone(),
 	    deprecation: self.deprecation.clone().map_or(false, |_| true),
+	    metadata: self.metadata.clone(),
 	}
     }
 }
@@ -412,6 +427,7 @@ pub struct ZomeVersionEntry {
     pub mere_memory_addr: EntryHash,
     pub mere_memory_hash: String,
     pub hdk_version: String,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 
 impl EntryModel for ZomeVersionEntry {
@@ -430,6 +446,7 @@ pub struct ZomeVersionSummary {
     pub mere_memory_addr: EntryHash,
     pub mere_memory_hash: String,
     pub hdk_version: String,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for ZomeVersionSummary {
     fn get_type(&self) -> EntityType {
@@ -448,6 +465,7 @@ pub struct ZomeVersionInfo {
     pub mere_memory_addr: EntryHash,
     pub mere_memory_hash: String,
     pub hdk_version: String,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for ZomeVersionInfo {
     fn get_type(&self) -> EntityType {
@@ -474,6 +492,7 @@ impl ZomeVersionEntry {
 	    mere_memory_addr: self.mere_memory_addr.clone(),
 	    mere_memory_hash: self.mere_memory_hash.clone(),
 	    hdk_version: self.hdk_version.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -486,6 +505,7 @@ impl ZomeVersionEntry {
 	    mere_memory_addr: self.mere_memory_addr.clone(),
 	    mere_memory_hash: self.mere_memory_hash.clone(),
 	    hdk_version: self.hdk_version.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 }
@@ -528,6 +548,7 @@ pub mod tests {
 		pubkey: hash.into(),
 	    },
 	    deprecation: None,
+	    metadata: HashMap::new(),
 	}
     }
 

--- a/devhub_types/src/happ_entry_types.rs
+++ b/devhub_types/src/happ_entry_types.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use hc_crud::{
     get_entity,
     EntryModel, EntityType, Entity
@@ -48,6 +49,7 @@ pub struct HappEntry {
     pub designer: AgentPubKey,
     pub published_at: u64,
     pub last_updated: u64,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -71,6 +73,7 @@ pub struct HappSummary {
     pub published_at: u64,
     pub last_updated: u64,
     pub deprecation: bool,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -90,6 +93,7 @@ pub struct HappInfo {
     pub designer: AgentPubKey,
     pub published_at: u64,
     pub last_updated: u64,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 
     // optional
     pub icon: Option<SerializedBytes>,
@@ -114,6 +118,7 @@ impl HappEntry {
 	    icon: self.icon.clone(),
 	    deprecation: self.deprecation.clone(),
 	    gui: self.gui.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -127,6 +132,7 @@ impl HappEntry {
 	    last_updated: self.last_updated.clone(),
 	    icon: self.icon.clone(),
 	    deprecation: self.deprecation.clone().map_or(false, |_| true),
+	    metadata: self.metadata.clone(),
 	}
     }
 }
@@ -217,6 +223,7 @@ pub struct HappReleaseEntry {
     pub dna_hash : String,
     pub hdk_version: String,
     pub dnas: Vec<DnaReference>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 
 impl EntryModel for HappReleaseEntry {
@@ -236,6 +243,7 @@ pub struct HappReleaseSummary {
     pub dna_hash : String,
     pub hdk_version: String,
     pub dnas: Vec<DnaReference>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for HappReleaseSummary {
     fn get_type(&self) -> EntityType {
@@ -255,6 +263,7 @@ pub struct HappReleaseInfo {
     pub dna_hash : String,
     pub hdk_version: String,
     pub dnas: Vec<DnaReference>,
+    pub metadata: HashMap<String, serde_yaml::Value>,
 }
 impl EntryModel for HappReleaseInfo {
     fn get_type(&self) -> EntityType {
@@ -282,6 +291,7 @@ impl HappReleaseEntry {
 	    dna_hash: self.dna_hash.clone(),
 	    hdk_version: self.hdk_version.clone(),
 	    dnas: self.dnas.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 
@@ -295,6 +305,7 @@ impl HappReleaseEntry {
 	    dna_hash: self.dna_hash.clone(),
 	    hdk_version: self.hdk_version.clone(),
 	    dnas: self.dnas.clone(),
+	    metadata: self.metadata.clone(),
 	}
     }
 }

--- a/tests/integration/test_dnarepo.js
+++ b/tests/integration/test_dnarepo.js
@@ -319,6 +319,9 @@ function basic_tests () {
 	let dna_input			= {
 	    "name": "Game Turns",
 	    "description": "A tool for turn-based games to track the order of player actions",
+	    "metadata": {
+		"labels": [ "game" ]
+	    }
 	};
 
 	let dna				= await alice.call( "dnarepo", "dna_library", "create_dna", dna_input );
@@ -335,6 +338,7 @@ function basic_tests () {
 
 	    expect( dna_info.name		).to.equal( dna_input.name );
 	    expect( dna_info.description	).to.equal( dna_input.description );
+	    expect( dna_info.metadata.labels[0]	).to.equal( "game" );
 
 	    first_header_hash		= dna_info.$header;
 	}

--- a/zomes/Cargo.lock
+++ b/zomes/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "hex",
  "rand",
  "serde",
+ "serde_yaml",
  "thiserror",
 ]
 

--- a/zomes/dna_library/src/dna.rs
+++ b/zomes/dna_library/src/dna.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput,
     dnarepo_entry_types::{ DnaEntry, DnaInfo, DnaSummary, DeveloperProfileLocation, DeprecationNotice },
@@ -37,6 +38,7 @@ pub struct DnaInput {
     pub icon: Option<SerializedBytes>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 pub fn create_dna(input: DnaInput) -> AppResult<Entity<DnaInfo>> {
@@ -62,6 +64,8 @@ pub fn create_dna(input: DnaInput) -> AppResult<Entity<DnaInfo>> {
 	    pubkey: pubkey.clone(),
 	},
 	deprecation: None,
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let entity = create_entity( &dna )?
@@ -189,6 +193,7 @@ pub struct DnaUpdateOptions {
     pub icon: Option<SerializedBytes>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type DnaUpdateInput = UpdateEntityInput<DnaUpdateOptions>;
 
@@ -215,6 +220,8 @@ pub fn update_dna(input: DnaUpdateInput) -> AppResult<Entity<DnaInfo>> {
 		    .unwrap_or( now()? ),
 		developer: current.developer,
 		deprecation: current.deprecation,
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 
@@ -259,6 +266,7 @@ pub fn deprecate_dna(input: DeprecateDnaInput) -> AppResult<Entity<DnaInfo>> {
 		last_updated: current.last_updated,
 		developer: current.developer,
 		deprecation: Some(DeprecationNotice::new( input.message.to_owned() )),
+		metadata: current.metadata,
 	    })
 	})?;
 

--- a/zomes/dna_library/src/dnaversions.rs
+++ b/zomes/dna_library/src/dnaversions.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput,
     dnarepo_entry_types::{
@@ -43,6 +44,7 @@ pub struct DnaVersionInput {
     pub changelog: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 pub fn create_dna_version(input: DnaVersionInput) -> AppResult<Entity<DnaVersionInfo>> {
@@ -66,6 +68,8 @@ pub fn create_dna_version(input: DnaVersionInput) -> AppResult<Entity<DnaVersion
 	    .unwrap_or( default_now ),
 	last_updated: input.last_updated
 	    .unwrap_or( default_now ),
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let version_path = dna_version_path( &version.wasm_hash )?;
@@ -129,6 +133,7 @@ pub struct DnaVersionUpdateOptions {
     pub changelog: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type DnaVersionUpdateInput = UpdateEntityInput<DnaVersionUpdateOptions>;
 
@@ -151,6 +156,8 @@ pub fn update_dna_version(input: DnaVersionUpdateInput) -> AppResult<Entity<DnaV
 		zomes: current.zomes,
 		changelog: props.changelog
 		    .unwrap_or( current.changelog ),
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 

--- a/zomes/dna_library/src/zome.rs
+++ b/zomes/dna_library/src/zome.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput,
     dnarepo_entry_types::{ ZomeEntry, ZomeInfo, ZomeSummary, DeveloperProfileLocation, DeprecationNotice },
@@ -35,6 +36,7 @@ pub struct ZomeInput {
     // optional
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 pub fn create_zome(input: ZomeInput) -> AppResult<Entity<ZomeInfo>> {
@@ -59,6 +61,8 @@ pub fn create_zome(input: ZomeInput) -> AppResult<Entity<ZomeInfo>> {
 	    pubkey: pubkey.clone(),
 	},
 	deprecation: None,
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let entity = create_entity( &zome )?
@@ -185,6 +189,7 @@ pub struct ZomeUpdateOptions {
     pub description: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type ZomeUpdateInput = UpdateEntityInput<ZomeUpdateOptions>;
 
@@ -209,6 +214,8 @@ pub fn update_zome(input: ZomeUpdateInput) -> AppResult<Entity<ZomeInfo>> {
 		    .unwrap_or( now()? ),
 		developer: current.developer,
 		deprecation: current.deprecation,
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 
@@ -252,6 +259,7 @@ pub fn deprecate_zome(input: DeprecateZomeInput) -> AppResult<Entity<ZomeInfo>> 
 		last_updated: current.last_updated,
 		developer: current.developer,
 		deprecation: Some(DeprecationNotice::new( input.message.to_owned() )),
+		metadata: current.metadata,
 	    })
 	})?;
 

--- a/zomes/dna_library/src/zomeversion.rs
+++ b/zomes/dna_library/src/zomeversion.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput,
     errors::{ UserError },
@@ -46,6 +47,7 @@ pub struct ZomeVersionInput {
     pub changelog: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 pub fn create_zome_version(input: ZomeVersionInput) -> AppResult<Entity<ZomeVersionInfo>> {
@@ -74,6 +76,8 @@ pub fn create_zome_version(input: ZomeVersionInput) -> AppResult<Entity<ZomeVers
 	last_updated: input.last_updated
 	    .unwrap_or( default_now ),
 	hdk_version: input.hdk_version.clone(),
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let entity = create_entity( &version )?
@@ -151,6 +155,7 @@ pub struct ZomeVersionUpdateOptions {
     pub changelog: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type ZomeVersionUpdateInput = UpdateEntityInput<ZomeVersionUpdateOptions>;
 
@@ -173,6 +178,8 @@ pub fn update_zome_version(input: ZomeVersionUpdateInput) -> AppResult<Entity<Zo
 		changelog: props.changelog
 		    .unwrap_or( current.changelog ),
 		hdk_version: current.hdk_version,
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 

--- a/zomes/happ_library/Cargo.toml
+++ b/zomes/happ_library/Cargo.toml
@@ -15,6 +15,7 @@ hc_crud_ceps = "0.17.0"
 hdk = "0.0.120"
 hex = "0"
 serde = "1"
+serde_yaml = "0.8.17"
 thiserror = "1"
 
 [dev-dependencies]

--- a/zomes/happ_library/src/happ.rs
+++ b/zomes/happ_library/src/happ.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput, GetEntityInput,
     happ_entry_types::{
@@ -48,6 +49,7 @@ pub struct CreateInput {
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
     pub gui: Option<GUIConfigInput>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 
@@ -80,6 +82,8 @@ pub fn create_happ(input: CreateInput) -> AppResult<Entity<HappInfo>> {
 	gui: input.gui.map(|gui| {
 	    HappGUIConfig::new( gui.asset_group_id, gui.uses_web_sdk )
 	}),
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let entity = create_entity( &happ )?
@@ -122,6 +126,7 @@ pub struct HappUpdateOptions {
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
     pub gui: Option<HappGUIConfig>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type HappUpdateInput = UpdateEntityInput<HappUpdateOptions>;
 
@@ -152,6 +157,8 @@ pub fn update_happ(input: HappUpdateInput) -> AppResult<Entity<HappInfo>> {
 		deprecation: current.deprecation,
 		gui: props.gui
 		    .or( current.gui ),
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 

--- a/zomes/happ_library/src/happ_release.rs
+++ b/zomes/happ_library/src/happ_release.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use devhub_types::{
     AppResult, UpdateEntityInput, GetEntityInput,
     happ_entry_types::{
@@ -45,6 +46,7 @@ pub struct CreateInput {
     // optional
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 
 pub fn create_happ_release(input: CreateInput) -> AppResult<Entity<HappReleaseInfo>> {
@@ -68,6 +70,8 @@ pub fn create_happ_release(input: CreateInput) -> AppResult<Entity<HappReleaseIn
 	dna_hash: hex::encode( devhub_types::hash_of_hashes( &hashes ) ),
 	hdk_version: input.hdk_version,
 	dnas: input.dnas,
+	metadata: input.metadata
+	    .unwrap_or( HashMap::new() ),
     };
 
     let release_path = happ_release_path( &happ_release.dna_hash )?;
@@ -100,6 +104,7 @@ pub struct HappReleaseUpdateOptions {
     pub description: Option<String>,
     pub published_at: Option<u64>,
     pub last_updated: Option<u64>,
+    pub metadata: Option<HashMap<String, serde_yaml::Value>>,
 }
 pub type HappReleaseUpdateInput = UpdateEntityInput<HappReleaseUpdateOptions>;
 
@@ -124,6 +129,8 @@ pub fn update_happ_release(input: HappReleaseUpdateInput) -> AppResult<Entity<Ha
 		dna_hash: current.dna_hash,
 		hdk_version: current.hdk_version,
 		dnas: current.dnas,
+		metadata: props.metadata
+		    .unwrap_or( current.metadata ),
 	    })
 	})?;
 


### PR DESCRIPTION
An optional `metadata` field to

- Zome types
- DNA types
- hApp types

This field is so that the front end can make progress independently when the changes do not affect validation rules.